### PR TITLE
Change error message to better reflect BMP pressure sensor

### DIFF
--- a/main/sensors.go
+++ b/main/sensors.go
@@ -85,7 +85,7 @@ func initPressureSensor() (ok bool) {
 	v, err := i2cbus.ReadByteFromReg(0x76, PRESSURE_WHO_AM_I)
 
 	if err != nil {
-		log.Printf("Error identifying IMU: %s\n", err.Error())
+		log.Printf("Error identifying BMP: %s\n", err.Error())
 		return false
 	}
 	if v == bmp388.ChipId || v == bmp388.ChipId390 {


### PR DESCRIPTION
Line 88 which is error message for BMP pressure sensors, but has the same error message as lines 181 and 186 which are for IMU. Update the error message for line 90 to BMP.